### PR TITLE
Fix a flak test  by cleaning a polluted state.

### DIFF
--- a/test/test_pyeventdispatcher.py
+++ b/test/test_pyeventdispatcher.py
@@ -54,6 +54,7 @@ class TestRegister:
         ],
     )
     def test_listeners_executed_in_order(self, to_register, output, capsys):
+        pyeventdispatcher.event_dispatcher.global_registry = MemoryRegistry()
         py_event_dispatcher = EventDispatcher()
         for register in to_register:
             py_event_dispatcher.register(


### PR DESCRIPTION
```
E       AssertionError: assert 'Second\nFirst\nglobal\n' == 'Second\nFirst\n'
E           Second
E           First
E         + global

test/test_pyeventdispatcher.py:66: AssertionError
```

```
python -m pytest test/test_pyeventdispatcher.py::TestRegisterGlobal::test_it_allows_to_register_listener_globally test/test_pyeventdispatcher.py::TestRegister::test_listeners_executed_in_order
```